### PR TITLE
delays.py change: import pyvisa as visa

### DIFF
--- a/pyTA/delays.py
+++ b/pyTA/delays.py
@@ -1,4 +1,4 @@
-import visa
+import pyvisa as visa
 from pipython import GCSDevice, pitools
 
 


### PR DESCRIPTION
Quick and easy change so that the following FutureWarning doesn't appear when first launching pyTA in the lab:

```
FutureWarning: The visa module provided by PyVISA is being deprecated. You can replace `import visa` by `import pyvisa as visa` to achieve the same effect.

The reason for the deprecation is the possible conflict with the visa package provided by the https://github.com/visa-sdk/visa-python which can result in hard to debug situations.
```