### PR TITLE
Quick fixes (note motor usage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ python hdf5-converter.py
 ```
 When finished run `conda deactivate`.
 
+### development ###
+
+Things to fix throughout the python code are denoted with `@todo`.
+
 ### key things to implement ###
 
  - [ ] Set up and test NIR detectors
@@ -33,6 +37,7 @@ When finished run `conda deactivate`.
 
  - [ ] Fix the quality control algorithm in `dtt.py` so that bad data is properly rejected but we don't get stuck in a loop of retaking the data point. Not sure yet what the solution is.
  - [x] Output correct metadata.txt file (e.g. seems to think we're always using the `short delay stage` currently), and output more things (the more information the better)
+ - [ ] **Properly** fix weird bug in saving which motor COM port was last used (seems to be due to putting a string into the `last_instance_values.txt`). Currently doesn't save it at all as a hack-fix!
  
 ### nice things to have ###
  - [x] Have *dark correction shots x* in the _Acquisition_ tab as well

--- a/pyTA/last_instance_values.txt
+++ b/pyTA/last_instance_values.txt
@@ -14,7 +14,7 @@ distribution:0.0
 tstart:-5.0
 tend:1000000.0
 num tpoints:200.0
-num shots:1000.0
+num shots:200.0
 num sweeps:5.0
 d use ref manip:1.0
 d display mode spectra:0.0
@@ -27,10 +27,10 @@ d threshold pixel:1.0
 d threshold value:20000.0
 d time:0.0
 d jogstep:1.0
-dark correction shot factor:8.0
-motor COM:COM6
-motor coosc index 1:1
-motor coosc index 2:2
+dark correction shot factor:4
+motor COM:
+motor coosc index 1:
+motor coosc index 2:
 motor coosc zero 1:4.5
 motor coosc zero 2:5.5
 motor coosc 1 target 1:6.5
@@ -38,5 +38,5 @@ motor coosc 1 target 2:2.5
 motor coosc 2 target 1:7.5
 motor coosc 2 target 2:3.5
 motor coosc delay:0.0
-motor move index:1
-motor move target:5.5
+motor move index:
+motor move target:5.0

--- a/pyTA/pyTA.py
+++ b/pyTA/pyTA.py
@@ -220,7 +220,7 @@ class Application(QtGui.QMainWindow):
             self.ui.coosc_m2_target2.setValue(self.last_instance_values['motor coosc 2 target 2'])
             self.ui.delay_spin.setValue(self.last_instance_values['motor coosc delay'])
             self.ui.move_target_spin.setValue(self.last_instance_values['motor move target'])
-            self.ui.d_dcshotfactor_sb.setValue(self.last_instance_values['dark correction shot factor'])
+            self.ui.d_dcshotfactor_sb.setValue(int(self.last_instance_values['dark correction shot factor']))
         
     def setup_gui_connections(self):
         # acquisition file stuff
@@ -395,7 +395,9 @@ class Application(QtGui.QMainWindow):
         self.last_instance_values['d threshold value'] = self.ui.d_threshold_value.value()
         self.last_instance_values['d time'] = self.ui.d_time.value()
         self.last_instance_values['d jogstep'] = self.ui.d_jogstep_sb.value()
-        self.last_instance_values['motor COM'] = self.motor_comport
+        self.last_instance_values['motor COM'] = []
+		# self.last_instance_values['motor COM'] = self.motor_comport
+		# @todo there is a weird bug here where if you save self.motor_comport, e.g. as 'COM6', all the last_instance_values.txt entries are recognised as strings (I guess because COM# is definitely a string, not a float). Yields a 'ValueError: invalid literal for int() with base 10' when you start pyTA.py. I've hacked a fix by just not saving the last motor COM port (looks blank in the last_instance_values.txt) but a better fix is needed - perhaps use numbers to represent COM ports, similar to the delay type?
         self.last_instance_values['motor coosc index 1'] = self.ui.motor_1_index_spin.currentText()
         self.last_instance_values['motor coosc index 2'] = self.ui.motor_2_index_spin.currentText()
         self.last_instance_values['motor coosc zero 1'] = self.ui.coosc_m1_zero.value()


### PR DESCRIPTION
If you want to use the motors, use COM6. (There was a weird bug in saving which motor COM port was last used in last_instance_values.txt which needs fixing properly; try searching @todo in pyTA.py).